### PR TITLE
Completed task 20.

### DIFF
--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -2,11 +2,11 @@ const { selectArticles, insertArticle, selectArticleByID, updateArticleByID } = 
 
 exports.getArticles = (request, response, next) =>
 {
-    const { topic, sort_by, order } = request.query;
-    selectArticles(topic, sort_by, order)
-        .then((articles) =>
+    const { topic, sort_by, order, limit, p } = request.query;
+    selectArticles(topic, sort_by, order, limit, p)
+        .then(([articles, total_count]) =>
         {
-            response.status(200).send({ articles });
+            response.status(200).send({ articles, total_count });
         })
         .catch(next);
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -17,7 +17,7 @@
     "GET /api/articles":
     {
         "description": "Serves an array of all articles.",
-        "queries": ["author", "topic", "sort_by", "order"],
+        "queries": ["topic", "sort_by", "order", "limit", "p"],
         "exampleResponse":
         {
             "articles":
@@ -32,7 +32,8 @@
                     "article_img_url": "https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?w=700&h=700",
                     "comment_count": 6
                 }
-            ]
+            ],
+            "total_count": 1
         }
     },
 


### PR DESCRIPTION
- Updated `GET /api/articles` with pagination:
  - Can be queried by `limit` for how many articles to get at a time (along with error handling and tests)
  - Can be queried by `p` for which page of articles to get (along with error handling and tests)
  - Earlier tests and `endpoints.json` have been slightly modified to reflect this update